### PR TITLE
Override setState with mounted check to fix crash

### DIFF
--- a/lib/src/widgets/paging_grid_view.dart
+++ b/lib/src/widgets/paging_grid_view.dart
@@ -130,6 +130,13 @@ class GridViewState<T> extends State<PagingGridView<T>> {
       }
     }
   }
+  
+  @override
+  void setState(fn) {
+    if(mounted) {
+      super.setState(fn);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Seeing a lot of the following crash in firebase

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value. Error thrown null.
       at State.setState(framework.dart:1134)
       at GridViewState._loadPage.<fn>(paging_grid_view.dart:73)
       at GridViewState._loadPage.<fn>(paging_grid_view.dart:72)
```

With this change of checking if the widget is mounted the crash is fixed, let me know if there is a better way to do it.